### PR TITLE
ci(build): upload compiled artifact & display job summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,16 @@ jobs:
 
       - name: Set job summary
         run: |
-          echo $(ls -lhp dist/ | grep -v '/$' | awk '{print $5, $9}') >> $GITHUB_STEP_SUMMARY
+          echo "$(ls -lhp dist/ | grep -v '/$' | awk '{print $5, $9}')" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload compiled Chrome extension
         uses: actions/upload-artifact@v4
         with:
+          name: catppuccin-github-file-explorer-icons-chrome
           path: dist/chrome-mv3
 
       - name: Upload compiled Firefox extension
         uses: actions/upload-artifact@v4
         with:
+          name: catppuccin-github-file-explorer-icons-firefox
           path: dist/firefox-mv2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,9 @@ jobs:
         run: |
           pnpm zip
           pnpm zip:firefox
+
+      - name: Upload compiled extension artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/*.zip
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,16 @@ jobs:
           pnpm zip
           pnpm zip:firefox
 
-      - name: Upload compiled extension artifacts
+      - name: Set job summary
+        run: |
+          echo $(ls -lhp dist/ | grep -v '/$' | awk '{print $5, $9}') >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload compiled Chrome extension
         uses: actions/upload-artifact@v4
         with:
-          path: dist/*.zip
+          path: dist/chrome-mv3
 
+      - name: Upload compiled Firefox extension
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/firefox-mv2


### PR DESCRIPTION
I think this means we can view the sizes of the artifacts to make sure nothing like https://togithub.com/wxt-dev/wxt/issues/738 happens again. Also just means you can verify/test the files in general.