### PR TITLE
feat: support new commit details page icons

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ const GITHUB_SELECTORS = {
 		'.octicon-file-submodule',
 		'.react-directory-filename-column > svg',
 		'[aria-label="Parent directory"] svg',
+		'.PRIVATE_TreeView-item-visual > svg',
 	],
 };
 


### PR DESCRIPTION
Adds support for the icons on the new commit details page beta.

![image](https://github.com/user-attachments/assets/12ec0443-b5c3-42d7-a9a7-f716c62d5cac)
