### PR TITLE
fix: disable icon injection on new commit details page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,11 @@
 const GITHUB_SELECTORS = {
 	row: [
 		'.js-navigation-container[role=grid] > .js-navigation-item',
+		// Old commit details and pull request file tree.
 		'file-tree .ActionList-content',
 		'a.tree-browser-result',
-		'.PRIVATE_TreeView-item-content',
+		// For the inner repository file sidepanel. Extra specificity to avoid matching icons on the new commit details page, which uses the same component.
+		'ul[aria-label="Files"] .PRIVATE_TreeView-item-content',
 		'.react-directory-filename-column',
 		'[aria-label="Parent directory"]',
 	],


### PR DESCRIPTION
Closes #154. I realized that I was wrong actually - the new commit details page, which is the one referenced in the issue/screenshot, was unintentionally having icons replaced, because it is the same component under the hood as the repository file tree (not on the repository home page, but click on a file/directory and then click the file tree sidebar). This PR just increases the specificity to exclude the commit details component and only keep the repository tree component.