### PR TITLE
fix: don't hide commit details file tree folder icons

### DIFF
--- a/src/entries/content/lib.ts
+++ b/src/entries/content/lib.ts
@@ -19,7 +19,7 @@ export async function injectStyles() {
 		.join('\n  ')}
 }
 
-.PRIVATE_TreeView-directory-icon svg {
+ul[aria-label="Files"] .PRIVATE_TreeView-directory-icon svg {
 	display: none !important;
 }
 


### PR DESCRIPTION
Slipped through from #155/#154 - the icons on the commit details page are no longer being injected, but the folder icons are still hidden. Simply adding the same more precise selector to the injected CSS here is a temporary fix.