### PR TITLE
fix(sites/tangled): update domain to tangled.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Applies Catppuccin-themed code/file icons to file explorers on the following sit
 - [Gitea](https://gitea.com)
 - [Forgejo](https://forgejo.org)
 - [Bitbucket](https://bitbucket.org)
-- [tangled.sh](https://tangled.sh)
+- [Tangled](https://tangled.org)
 
 ## Usage
 

--- a/src/sites/tangled.ts
+++ b/src/sites/tangled.ts
@@ -35,6 +35,6 @@ details:not([open]) > summary > .tree-directory svg[${ATTRIBUTE_PREFIX}]:not([${
 	`.trim();
 
 export const tangled: Site = {
-	domains: ['tangled.sh'],
+	domains: ['tangled.org'],
 	replacements: [mainRepositoryImplementation, commitTreeImplementation],
 };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -84,7 +84,7 @@ export default defineConfig({
 			'https://gitea.com/gitea/gitea-mirror',
 			'https://gitea.catppuccin.com/catppuccin/catppuccin',
 			'https://bitbucket.org/atlassian/atlassian-frontend-mirror',
-			'https://tangled.sh/@tangled.sh/core',
+			'https://tangled.org/@tangled.org/core',
 		],
 	},
 });


### PR DESCRIPTION
Fixes the icons not being replaced on Tangled, because I had forgotten that the change from the tangled.sh domain to the tangled.org domain would mess with the extension! Readme listing fixed, example/testing site fixed, configuration fixed so it is now working as expected.