### PR TITLE
Add new FAQ to the README.md + Add MIT badge on top of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,3 @@ See [the contributing guide](./CONTRIBUTING.md).
 <p align="center">
 	Copyright &copy; 2021-present <a href="https://github.com/catppuccin" target="_blank">Catppuccin Org</a>
 </p>
-
-<p align="center">
-	<a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE"><img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=363a4f&colorB=b7bdf8"/></a>
-</p>

--- a/README.md
+++ b/README.md
@@ -100,8 +100,15 @@ This extension aims to provide the same configuration options as [catppuccin/vsc
 
 ## 🙋 FAQ
 
-- Q: **_"How can I enable this extension on a custom domain?"_**\
+- Q: **_"How can I enable this extension on a custom domain?"_**  
   A: See [fregante.github.io/webext-permission-toggle](https://fregante.github.io/webext-permission-toggle/?name=Catppuccin+for+Web+File+Explorer+Icons&icon=https://raw.githubusercontent.com/catppuccin/web-file-explorer-icons/main/src/assets/icon.png).
+
+- Q: **_"Where can I learn more about Catppuccin themes?"_**  
+  A: Visit the [official Catppuccin documentation](https://catppuccin.com/).
+
+- Q: **_"Where do I report bugs or suggest new icons?"_**  
+  A: Open an issue on [GitHub Issues](https://github.com/catppuccin/web-file-explorer-icons/issues).
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,20 @@
 </h3>
 
 <p align="center">
-	<a href="https://github.com/catppuccin/web-file-explorer-icons/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
-	<a href="https://github.com/catppuccin/web-file-explorer-icons/issues"><img src="https://img.shields.io/github/issues/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
-	<a href="https://github.com/catppuccin/web-file-explorer-icons/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
+  <a href="https://github.com/catppuccin/web-file-explorer-icons/stargazers">
+    <img src="https://img.shields.io/github/stars/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=b7bdf8&style=for-the-badge" alt="Stars">
+  </a>
+  <a href="https://github.com/catppuccin/web-file-explorer-icons/issues">
+    <img src="https://img.shields.io/github/issues/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=f5a97f&style=for-the-badge" alt="Issues">
+  </a>
+  <a href="https://github.com/catppuccin/web-file-explorer-icons/contributors">
+    <img src="https://img.shields.io/github/contributors/catppuccin/web-file-explorer-icons?colorA=363a4f&colorB=a6da95&style=for-the-badge" alt="Contributors">
+  </a>
+  <a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE">
+    <img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=363a4f&colorB=b7bdf8" alt="License: MIT">
+  </a>
 </p>
+
 
 <p align="center">
   <img src="https://github.com/catppuccin/vscode-icons/raw/main/assets/catwalk.webp" width=600/>


### PR DESCRIPTION
## Description

This pull request adds a new FAQ entry to the README, providing a direct link to the official Catppuccin website.  
It improves discoverability for users who want to learn more about Catppuccin themes and related projects.

## Type of Change

- [x] Documentation update
- [x] Report a bug

## How Has This Been Tested?

- [x] Manually reviewed README rendering in GitHub preview to ensure formatting and link display correctly.

## Checklist

- [x] My changes follow the style and tone of the existing README.
- [x] I verified that the link points to the correct and active Catppuccin website.
- [x] The README renders properly after the change.
- [x] The user can be guided to submit page if they find a bug from README