### PR TITLE
feat: add new `setupObserver` API 

### DIFF
--- a/src/entries/content/index.ts
+++ b/src/entries/content/index.ts
@@ -39,8 +39,16 @@ function runReplacements(
 	for (const replacement of replacements) {
 		observe(replacement.row, {
 			async add(rowEl: HTMLElement) {
-				await replaceIconInRow(rowEl, replacement);
-			},
+				if (replacement.setupObserver) {
+					replacement.setupObserver(
+						rowEl,
+						() => replaceIconInRow(rowEl, replacement)
+					)
+				}
+				else {
+					await replaceIconInRow(rowEl, replacement);
+				}
+			}
 		});
 	}
 

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -19,6 +19,15 @@ export type ReplacementSelectorSet = {
 	isSubmodule: FnWithContext<boolean>;
 	isCollapsable: FnWithContext<boolean>;
 	getFilename?: FnWithContext<string>;
+	/**
+	 * Setup a manual row observer and call {@link replace} when you
+	 * to replace the icon properly in the row.
+	 *
+	 * If not given, the classic behavior will be used; should work for
+	 * most cases, use this only for very specific behaviors (e.g. DOM nodes
+	 * are re-used for a new row).
+	 */
+	setupObserver?: (row: HTMLElement, replace: () => Promise<void>) => Promise<void>;
 	styles?: string;
 };
 


### PR DESCRIPTION
Allows people to add manual extra observers when a new row has been detected by the original observer.

Needed for https://github.com/catppuccin/web-file-explorer-icons/pull/245