### PR TITLE
fix: replaced icon should not copy `style` from original icon

### DIFF
--- a/src/entries/content/lib.ts
+++ b/src/entries/content/lib.ts
@@ -44,6 +44,7 @@ async function createIconElement(
 			!(
 				attribute.startsWith(ATTRIBUTE_PREFIX) ||
 				[
+					'style', // let's not copy our manual `display: none`
 					'viewBox',
 					'stroke-width',
 					'stroke-linecap',


### PR DESCRIPTION
Prevents to copy `display: none` we added during the first iteration.